### PR TITLE
Move grpc-error to devDependencies/peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
     "version": "uphold-scripts version"
   },
   "dependencies": {
-    "grpc-error": "^1.0.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
     "grpc": "^1.24.2",
     "grpc-caller": "^0.13.0",
+    "grpc-error": "^1.0.0",
     "mali": "^0.20.0",
     "uphold-scripts": "^0.4.0"
+  },
+  "peerDependencies": {
+    "grpc-error": "^1.0.0"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
This prevents this package from installing its own copy of grpc-error in parent packages that have this package as a dependency, as that may result in incompatible copies of the grpc-error dependency in the parent package if it already requires grpc-error via some other dependency path.
