### PR TITLE
Make codebase compatible with Node.js v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "grpc-error": "^1.0.0"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "jest": {
     "coverageThreshold": {
       "global": {

--- a/src/mappers/grpc-error-mapper.js
+++ b/src/mappers/grpc-error-mapper.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const codes = require('../enums/grpc-status-codes-enum');
 const messages = require('../enums/grpc-status-messages-enum');
 const GrpcError = require('grpc-error');
@@ -12,7 +13,7 @@ const GrpcError = require('grpc-error');
  * Constants.
  */
 
-const STATUS_CODE_TO_NAME = Object.fromEntries(Object.entries(codes).map(code => code.reverse()));
+const STATUS_CODE_TO_NAME = _.invert(codes);
 
 /**
  * Class `GrpcErrorMapper`.


### PR DESCRIPTION
`Object.fromEntries()` is an ES2019 feature, which was introduced in Node.js v12.
It was the only v12-only feature in this codebase, and was used as part of code that swapped the keys and values of an object.
This is a task that lodash (a dependency that we already have) can also perform with its `invert` function, so replacing that use of `Object.fromEntries()` with `lodash.invert()` allows this package to become compatible with Node.js v10.
